### PR TITLE
Change requirements to use upstream actualpy since HA now supports Pydantic V2

### DIFF
--- a/custom_components/actualbudget/manifest.json
+++ b/custom_components/actualbudget/manifest.json
@@ -8,7 +8,7 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/jlvcm/ha-actualbudget/issues",
   "requirements": [
-    "actualpy @ git+https://github.com/jlvcm/actualpy-pydanticv1.git@0.6.1.3-pydanticv1"
+    "actualpy==0.6.1"
   ],
   "version": "1.0.3"
 }


### PR DESCRIPTION
Home Assistant has moved to [Pydantic v2 as of v2025.1](https://developers.home-assistant.io/blog/2024/12/21/moving-to-pydantic-v2/)

This PR drops the custom actualpy fork and switches to use the upstream actualpy library.

With this change I was able to install and configure the custom integration.

It may require further testing. I did get a bunch of errors where the connection to Actual was dropped. However I don't know if this is an issue with my setup or with the integration because I am a first time user of this intergration.

Fixes #15 