### PR TITLE
Only fetch budgets of the current month

### DIFF
--- a/custom_components/actualbudget/actualbudget.py
+++ b/custom_components/actualbudget/actualbudget.py
@@ -130,7 +130,7 @@ class ActualBudget:
 
     def get_budgets_sync(self) -> List[Budget]:
         session = self.get_session()
-        budgets_raw = get_budgets(session)
+        budgets_raw = get_budgets(session, datetime.date.today())
         budgets: Dict[str, Budget] = {}
         for budget_raw in budgets_raw:
             if not budget_raw.category:


### PR DESCRIPTION
This solves an issue where the budget amounts for all months are pulled from the server and the values of the sensors in HA may have unexpected values when budgets for future months have already been set.