### PR TITLE
Add uncategorized transactions count sensor

### DIFF
--- a/custom_components/actualbudget/actualbudget.py
+++ b/custom_components/actualbudget/actualbudget.py
@@ -11,7 +11,7 @@ from actual.exceptions import (
     InvalidZipFile,
     AuthorizationError,
 )
-from actual.queries import get_accounts, get_account, get_budgets, get_category
+from actual.queries import get_accounts, get_account, get_budgets, get_category, get_transactions
 from requests.exceptions import ConnectionError, SSLError
 import datetime
 import threading
@@ -181,6 +181,16 @@ class ActualBudget:
         category_data = get_category(session, budget_name)
         budget.balance = category_data.balance if category_data else Decimal(0)
         return budget
+
+    async def get_uncategorized_transactions_count(self) -> int:
+        """Get count of uncategorized transactions."""
+        return await self.hass.async_add_executor_job(self.get_uncategorized_transactions_count_sync)
+
+    def get_uncategorized_transactions_count_sync(self) -> int:
+        """Get count of uncategorized transactions synchronously."""
+        session = self.get_session()
+        transactions = get_transactions(session)
+        return sum(1 for tx in transactions if tx.category is None)
 
     async def test_connection(self):
         return await self.hass.async_add_executor_job(self.test_connection_sync)

--- a/custom_components/actualbudget/const.py
+++ b/custom_components/actualbudget/const.py
@@ -3,6 +3,7 @@ PLATFORM = "sensor"
 DOMAIN_DATA = f"{DOMAIN}_data"
 
 DEFAULT_ICON = "mdi:bank"
+DEFAULT_ICON_UNCATEGORIZED = "mdi:help-circle-outline"
 
 CONFIG_ENDPOINT = "endpoint"
 CONFIG_PASSWORD = "password"

--- a/custom_components/actualbudget/strings.json
+++ b/custom_components/actualbudget/strings.json
@@ -32,5 +32,10 @@
     "abort": {
       "already_configured": "Device is already configured"
     }
+  },
+  "entity": {
+    "sensor": {
+      "uncategorized_transactions": "Uncategorized Transactions"
+    }
   }
 }

--- a/custom_components/actualbudget/translations/da.json
+++ b/custom_components/actualbudget/translations/da.json
@@ -32,5 +32,10 @@
     "abort": {
       "already_configured": "Enheden er allerede sat op"
     }
+  },
+  "entity": {
+    "sensor": {
+      "uncategorized_transactions": "Ikke-kategoriserede transaktioner"
+    }
   }
 }

--- a/custom_components/actualbudget/translations/en.json
+++ b/custom_components/actualbudget/translations/en.json
@@ -32,5 +32,10 @@
     "abort": {
       "already_configured": "Device is already configured"
     }
+  },
+  "entity": {
+    "sensor": {
+      "uncategorized_transactions": "Uncategorized Transactions"
+    }
   }
 }

--- a/custom_components/actualbudget/translations/pt.json
+++ b/custom_components/actualbudget/translations/pt.json
@@ -32,5 +32,10 @@
     "abort": {
       "already_configured": "Já configurado"
     }
+  },
+  "entity": {
+    "sensor": {
+      "uncategorized_transactions": "Transações não categorizadas"
+    }
   }
 }


### PR DESCRIPTION
Adds a simple sensor that shows the count of uncategorized transactions in Actual Budget.

The sensor displays an integer count and updates alongside other sensors. Useful for monitoring transactions that still need categorization.