### PR TITLE
Bump actualpy to 0.21.0

### DIFF
--- a/custom_components/actualbudget/manifest.json
+++ b/custom_components/actualbudget/manifest.json
@@ -7,6 +7,6 @@
   "documentation": "https://github.com/jlvcm/ha-actualbudget/blob/main/README.md",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/jlvcm/ha-actualbudget/issues",
-  "requirements": ["actualpy==0.13.0"],
+  "requirements": ["actualpy==0.21.0"],
   "version": "3.0.0"
 }


### PR DESCRIPTION
## Summary
- bump `actualpy` from `0.13.0` to `0.21.0`

## Why
The current `0.13.0` pin is stale and causes budget sensor lookups to fail in Home Assistant, leaving budget sensors at `$0`. Updating to `0.21.0` fixes that behavior.

It looks like 9e208821019a68557bf349a073e47aba4ed1b5fe reverted the manifest from #49 which had set this to be an version greater than 0.12.0, which resolved to 0.21.0. This pins it to the correct, latest, version.