### PR TITLE
fix: restore state_class on monetary sensors

### DIFF
--- a/custom_components/actualbudget/sensor.py
+++ b/custom_components/actualbudget/sensor.py
@@ -6,7 +6,7 @@ import datetime
 import logging
 from typing import Dict, Union
 
-from homeassistant.components.sensor import SensorEntity
+from homeassistant.components.sensor import SensorEntity, SensorStateClass
 from homeassistant.components.sensor.const import SensorDeviceClass
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -51,6 +51,7 @@ class ActualBudgetAccountSensor(CoordinatorEntity[ActualBudgetCoordinator], Sens
     """Account balance sensor backed by the coordinator snapshot."""
 
     _attr_device_class = SensorDeviceClass.MONETARY
+    _attr_state_class = SensorStateClass.TOTAL
     _attr_icon = DEFAULT_ICON
 
     def __init__(
@@ -101,6 +102,7 @@ class ActualBudgetBudgetSensor(CoordinatorEntity[ActualBudgetCoordinator], Senso
     """Budget category balance sensor backed by the coordinator snapshot."""
 
     _attr_device_class = SensorDeviceClass.MONETARY
+    _attr_state_class = SensorStateClass.TOTAL
     _attr_icon = DEFAULT_ICON
 
     def __init__(


### PR DESCRIPTION
## Problem

The 3.0.0 DataUpdateCoordinator refactor accidentally dropped `state_class` from `ActualBudgetAccountSensor` and `ActualBudgetBudgetSensor`. Any user who had previously recorded long-term statistics for these entities now sees a HA repair warning: *"The entity no longer has a state class"*.

## Fix

Import `SensorStateClass` and add `_attr_state_class = SensorStateClass.TOTAL` to both monetary sensor classes. `TOTAL` is the value HA requires for `SensorDeviceClass.MONETARY`.

## Testing

After reloading the integration, the repair warnings disappear and long-term statistics resume recording normally.

Fixes #53 